### PR TITLE
update to sn_dbc 2.18.0 and make wallet Tx processing more robust against errors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.44"
-sn_dbc = {git="https://github.com/dan-da/sn_dbc.git", features = ["serdes", "mock"], branch="mock_feature"}
+sn_dbc = {git="https://github.com/dan-da/sn_dbc.git", features = ["serdes", "mock"], branch="examples_integration"}
+# sn_dbc = {git="https://github.com/maidsafe/sn_dbc.git", features = ["serdes", "mock"]}
 structopt = "0.3.25"
 tokio = { version = "1.16.1", features = ["rt-multi-thread", "macros", "io-util"] }
 serde = "1.0.130"
@@ -19,7 +20,8 @@ bytes = "1.1.0"
 rustyline = "9.0.0"
 chrono = {version = "0.4.19", features = ["serde"]}
 hex = "0.4.3"
-bls_dkg = "0.10.0"
+# bls_dkg = "0.10.0"
+bls_dkg = {path = "/home/danda/dev/maidsafe/bls_dkg"}
 xor_name = "4.0.1"
 ron = "0.7.0"
 thiserror = "1.0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.44"
-sn_dbc = {git="https://github.com/dan-da/sn_dbc.git", features = ["serdes", "mock"], branch="examples_integration"}
+sn_dbc = {version = "2.18.0", features = ["serdes", "mock"]}
 # sn_dbc = {git="https://github.com/maidsafe/sn_dbc.git", features = ["serdes", "mock"]}
 structopt = "0.3.25"
 tokio = { version = "1.16.1", features = ["rt-multi-thread", "macros", "io-util"] }
@@ -20,8 +20,7 @@ bytes = "1.1.0"
 rustyline = "9.0.0"
 chrono = {version = "0.4.19", features = ["serde"]}
 hex = "0.4.3"
-# bls_dkg = "0.10.0"
-bls_dkg = {path = "/home/danda/dev/maidsafe/bls_dkg"}
+bls_dkg = "0.10.1"
 xor_name = "4.0.1"
 ron = "0.7.0"
 thiserror = "1.0.30"

--- a/src/bin/wallet.rs
+++ b/src/bin/wallet.rs
@@ -459,14 +459,15 @@ impl WalletNodeClient {
         let mut rng = rng::thread_rng();
         let recip_owner_once = OwnerOnce::from_owner_base(owner_base, &mut rng);
 
-        let mut tx_builder = TransactionBuilder::default();
+        let mut tx_builder = TransactionBuilder::default()
+            .set_require_all_decoys(false);   // fixme: remove
 
         // let mut inputs_hash: BTreeMap<KeyImage, [u8; 32]> = Default::default();
 
         let unspent = self.unspent()?;
         for (dinfo, secret_key, _amount_secrets, _id, _ownership) in unspent.iter() {
             tx_builder = tx_builder
-                .add_input_dbc(&dinfo.dbc, secret_key, vec![], &mut rng)
+                .add_input_dbc(&dinfo.dbc, secret_key)
                 .into_diagnostic()?;
 
             if tx_builder.inputs_amount_sum() >= spend_amount {
@@ -636,7 +637,7 @@ impl WalletNodeClient {
             println!(
                 "{}, rcvd: {}, amount: {} ({})",
                 id,
-                dinfo.received.to_rfc3339(),
+                dinfo.received.with_timezone(&chrono::Local).format("%Y-%m-%d %H:%M:%S"),
                 amount_secrets.amount(),
                 ownership
             );


### PR DESCRIPTION
Updates the examples to use sn_dbc 2.18.0.   This required some minor changes to use the new sn_dbc mock feature/module.

Also implements an important fix to make wallet transaction processing more robust against failure, such as when a spentbook node is not available.

There are a few aspects to this:

1. The wallet now saves each Tx to the wallet.dat file before attempting it.
2. If an error occurs with any spentbook node, remaining nodes are tried instead of erroring out immediately.
3. When reissue command is invoked the wallet first checks if there is a pending (incomplete) Tx. If one is found, it notifies user and asks if it should retry.  If yes, the Tx is retried.   If no, the reissue is cancelled.